### PR TITLE
Enable building auto-targeting by default

### DIFF
--- a/mods/ura/mod.yaml
+++ b/mods/ura/mod.yaml
@@ -53,6 +53,13 @@ Rules:
 	ura|rules/ships.yaml
 	ura|rules/fakes.yaml
 
+	#RA Unplugged override rules
+	ura|rules/unplugged/aircraft.yaml
+	ura|rules/unplugged/defaults.yaml
+	ura|rules/unplugged/infantry.yaml
+	ura|rules/unplugged/ships.yaml
+	ura|rules/unplugged/vehicles.yaml
+
 Sequences:
 	ura|sequences/ships.yaml
 	ura|sequences/vehicles.yaml

--- a/mods/ura/rules/unplugged/aircraft.yaml
+++ b/mods/ura/rules/unplugged/aircraft.yaml
@@ -1,0 +1,11 @@
+MIG:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+YAK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+HELI:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+	
+HIND:
+	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/campaign-rules.yaml
+++ b/mods/ura/rules/unplugged/campaign-rules.yaml
@@ -1,0 +1,42 @@
+Player:
+	-ConquestVictoryConditions:
+	MissionObjectives:
+		EarlyGameOver: true
+	Shroud:
+		FogLocked: True
+		FogEnabled: True
+		ExploredMapLocked: True
+		ExploredMapEnabled: False
+	PlayerResources:
+		DefaultCashLocked: True
+		DefaultCash: 0
+
+World:
+	CrateSpawner:
+		Enabled: False
+		Locked: True
+	-SpawnMPUnits:
+	-MPStartLocations:
+	ObjectivesPanel:
+		PanelName: MISSION_OBJECTIVES
+	MapBuildRadius:
+		AllyBuildRadiusLocked: True
+		AllyBuildRadiusEnabled: False
+	MapOptions:
+		TechLevelLocked: True
+		ShortGameLocked: True
+		ShortGameEnabled: False
+
+E7:
+	-Crushable:
+
+E7.noautotarget:
+	Inherits: E7
+	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:
+	-AttackMove:
+	RenderSprites:
+		Image: E7
+
+^Vehicle:
+	Demolishable:

--- a/mods/ura/rules/unplugged/defaults.yaml
+++ b/mods/ura/rules/unplugged/defaults.yaml
@@ -1,0 +1,46 @@
+-^AutoTargetGround:
+
+-^AutoTargetGroundAssaultMove:
+
+-^AutoTargetAll:
+
+-^AutoTargetAllAssaultMove:
+
+^AutoTargetGround:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetGroundAssaultMove:
+	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
+	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything && !assault-move
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Defense
+		InvalidTargets: NoAutoTarget, WaterStructure
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything || assault-move
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
+	AttackMove:
+		AssaultMoveScanCondition: assault-move
+
+^AutoTargetAll:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAllAssaultMove:
+	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
+	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything && !assault-move
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Defense
+		InvalidTargets: NoAutoTarget, WaterStructure
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything || assault-move
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+	AttackMove:
+		AssaultMoveScanCondition: assault-move

--- a/mods/ura/rules/unplugged/infantry.yaml
+++ b/mods/ura/rules/unplugged/infantry.yaml
@@ -1,0 +1,26 @@
+E1:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+E2:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+E3:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+E4:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+SPY:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+E7:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+SHOK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+Zombie:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+Ant:
+	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/ships.yaml
+++ b/mods/ura/rules/unplugged/ships.yaml
@@ -1,0 +1,14 @@
+SS:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+MSUB:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+DD:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+CA:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+PT:
+	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/vehicles.yaml
+++ b/mods/ura/rules/unplugged/vehicles.yaml
@@ -1,0 +1,35 @@
+V2RL:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+1TNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+2TNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+3TNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+4TNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+ARTY:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+JEEP:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+APC:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+TTNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+FTRK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+CTNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround
+
+STNK:
+	Inherits@AUTOTARGET: ^AutoTargetGround


### PR DESCRIPTION
Targets #9 , #10 

Adds with it a full copy of _campaign-rules.yaml_ with a redefined _E7.noautotarget_.

A very interesting, very specific lua error occurs with mission _allies-01_, somehow in relation to '/rules/unplugged/defaults.yaml' to which it can't deal with the definitions' initial removal in lines 1-7. Every other .yaml organization with the exact same code will work with this map and the error occurs with this campaign map exclusively. In order to reproduce the error one will have to change the map.yaml to reference 'ura|rules/unplugged/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml'.

I'll be dropping the official campaign missions from the mod so no big deal but I spent some time narrowing the issue down so worth mentioning.