### PR TITLE
Update playtest yaml files 2

### DIFF
--- a/mods/ura/rules/unplugged/playtest-rules.yaml
+++ b/mods/ura/rules/unplugged/playtest-rules.yaml
@@ -101,6 +101,10 @@ MIG:
 
 # UNITS - SHIPS
 
+SS:
+	RevealsShroud:
+		Range: 8c0
+
 LST:
 	Cargo:
 		MaxWeight: 15
@@ -120,5 +124,9 @@ SYRD:
 # DEFENSIVE STRUCTURES
 
 # FAKE STRUCTURES
+
+^FakeBuilding:
+	Explodes:
+		DamageThreshold: 80
 
 # CIVILIAN STRUCTURES

--- a/mods/ura/weapons/unplugged/playtest-weapons.yaml
+++ b/mods/ura/weapons/unplugged/playtest-weapons.yaml
@@ -23,6 +23,14 @@ Maverick:
 		Versus: 
 			Heavy: 115
 
+SubMissile:
+	Projectile: Bullet
+		Inaccuracy: 1c512
+
+8Inch:
+	Range: 18c0
+	Inaccuracy: 2c512
+
 SilencedPPK:	
 	Range: 4c0
 


### PR DESCRIPTION
Adds (partially) balance changes from Smitty's latest balance patch:

Submissile inaccuracy (1c512 from 2c938)
Cruiser inaccuracy (2.512 from 2.938)

Cruiser range (+2c0)

Submarine vision (+2c0)

Fake structures increased damage treshold (+10%)