### PR TITLE
add ^AutoTargetAll to AA units

### DIFF
--- a/mods/ura/rules/unplugged/aircraft.yaml
+++ b/mods/ura/rules/unplugged/aircraft.yaml
@@ -5,7 +5,7 @@ YAK:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 
 HELI:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	
 HIND:
 	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/infantry.yaml
+++ b/mods/ura/rules/unplugged/infantry.yaml
@@ -5,7 +5,7 @@ E2:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 
 E3:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 
 E4:
 	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/ships.yaml
+++ b/mods/ura/rules/unplugged/ships.yaml
@@ -2,10 +2,10 @@ SS:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 
 MSUB:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 
 DD:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 
 CA:
 	Inherits@AUTOTARGET: ^AutoTargetGround

--- a/mods/ura/rules/unplugged/vehicles.yaml
+++ b/mods/ura/rules/unplugged/vehicles.yaml
@@ -11,7 +11,7 @@ V2RL:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 
 4TNK:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 
 ARTY:
 	Inherits@AUTOTARGET: ^AutoTargetGround
@@ -26,7 +26,7 @@ TTNK:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 
 FTRK:
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAll
 
 CTNK:
 	Inherits@AUTOTARGET: ^AutoTargetGround


### PR DESCRIPTION
Missing from #11

Allows AA units to auto-fire on air units within range.